### PR TITLE
Review: Revert some unnecessary changes and renaming to reflect the purpose

### DIFF
--- a/Source/NSubstitute/Core/CallResults.cs
+++ b/Source/NSubstitute/Core/CallResults.cs
@@ -21,7 +21,7 @@ namespace NSubstitute.Core
 
         public bool HasResultFor(ICall call)
         {
-            if (SkipVoidCall(call)) return false;
+            if (ReturnsVoidFrom(call)) return false;
             return _results.Any(x => x.IsResultFor(call));
         }
 
@@ -38,10 +38,7 @@ namespace NSubstitute.Core
             _results = new ConcurrentQueue<ResultForCallSpec>();
         }
 
-        /// <summary>
-        /// API to allow creation of custom <see cref="CallResults"/> which do not skip void methods.
-        /// </summary>
-        protected virtual bool SkipVoidCall(ICall call)
+        bool ReturnsVoidFrom(ICall call)
         {
             return call.GetReturnType() == typeof(void);
         }

--- a/Source/NSubstitute/Routing/Handlers/InvokeCustomHandlers.cs
+++ b/Source/NSubstitute/Routing/Handlers/InvokeCustomHandlers.cs
@@ -2,11 +2,11 @@
 
 namespace NSubstitute.Routing.Handlers
 {
-    public class InvokeCustomHandlers : ICallHandler
+    public class ReturnFromCustomHandlers : ICallHandler
     {
         private readonly ICustomHandlers _customHandlers;
 
-        public InvokeCustomHandlers(ICustomHandlers customHandlers)
+        public ReturnFromCustomHandlers(ICustomHandlers customHandlers)
         {
             _customHandlers = customHandlers;
         }

--- a/Source/NSubstitute/Routing/RouteFactory.cs
+++ b/Source/NSubstitute/Routing/RouteFactory.cs
@@ -75,7 +75,7 @@ namespace NSubstitute.Routing
                 , new ReturnConfiguredResultHandler(state.CallResults)
                 , new ReturnResultForTypeHandler(state.ResultsForType)
                 , new ReturnFromBaseIfRequired(state.SubstituteConfig, state.CallBaseExclusions)
-                , new InvokeCustomHandlers(state.CustomHandlers)
+                , new ReturnFromCustomHandlers(state.CustomHandlers)
                 , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.AutoValuesCallResults, state.CallSpecificationFactory)
                 , new ReturnFromAndConfigureDynamicCall(state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()


### PR DESCRIPTION
I wasn't sure that you still need `SkipVoidCall`. Do you?