### PR TITLE
Update redundant arg matcher message to include example uses

### DIFF
--- a/src/NSubstitute/Core/Arguments/ArgumentSpecificationCompatibilityTester.cs
+++ b/src/NSubstitute/Core/Arguments/ArgumentSpecificationCompatibilityTester.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Reflection;
+
+namespace NSubstitute.Core.Arguments
+{
+    public class ArgumentSpecificationCompatibilityTester : IArgumentSpecificationCompatibilityTester
+    {
+        private readonly IDefaultChecker _defaultChecker;
+
+        public ArgumentSpecificationCompatibilityTester(IDefaultChecker defaultChecker)
+        {
+            _defaultChecker = defaultChecker ?? throw new ArgumentNullException(nameof(defaultChecker));
+        }
+
+        public bool IsSpecificationCompatible(IArgumentSpecification specification, object argumentValue, Type argumentType)
+        {
+            var typeArgSpecIsFor = specification.ForType;
+            return AreTypesCompatible(argumentType, typeArgSpecIsFor)
+                   && IsProvidedArgumentTheOneWeWouldGetUsingAnArgSpecForThisType(argumentValue, typeArgSpecIsFor);
+        }
+
+        private bool IsProvidedArgumentTheOneWeWouldGetUsingAnArgSpecForThisType(object argument, Type typeArgSpecIsFor)
+        {
+            return _defaultChecker.IsDefault(argument, typeArgSpecIsFor);
+        }
+
+        private bool AreTypesCompatible(Type argumentType, Type typeArgSpecIsFor)
+        {
+            return argumentType.IsAssignableFrom(typeArgSpecIsFor) ||
+                (argumentType.IsByRef && !typeArgSpecIsFor.IsByRef && argumentType.IsAssignableFrom(typeArgSpecIsFor.MakeByRefType()));
+        }
+    }
+}

--- a/src/NSubstitute/Core/Arguments/IArgumentSpecificationCompatibilityTester.cs
+++ b/src/NSubstitute/Core/Arguments/IArgumentSpecificationCompatibilityTester.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace NSubstitute.Core.Arguments
+{
+    public interface IArgumentSpecificationCompatibilityTester
+    {
+        bool IsSpecificationCompatible(IArgumentSpecification specification, object argumentValue, Type argumentType);
+    }
+}

--- a/src/NSubstitute/Core/Arguments/ISuppliedArgumentSpecifications.cs
+++ b/src/NSubstitute/Core/Arguments/ISuppliedArgumentSpecifications.cs
@@ -5,6 +5,7 @@ namespace NSubstitute.Core.Arguments
 {
     public interface ISuppliedArgumentSpecifications
     {
+        IEnumerable<IArgumentSpecification> AllSpecifications { get; }
         bool AnyFor(object argument, Type argumentType);
         bool IsNextFor(object argument, Type argumentType);
         IArgumentSpecification Dequeue();

--- a/src/NSubstitute/Core/Arguments/MixedArgumentSpecificationsFactory.cs
+++ b/src/NSubstitute/Core/Arguments/MixedArgumentSpecificationsFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using NSubstitute.Exceptions;
 
 namespace NSubstitute.Core.Arguments
 {
@@ -17,13 +18,18 @@ namespace NSubstitute.Core.Arguments
         public IEnumerable<IArgumentSpecification> Create(IList<IArgumentSpecification> argumentSpecs, object[] arguments, IParameterInfo[] parameterInfos)
         {
             var suppliedArgumentSpecifications = _suppliedArgumentSpecificationsFactory.Create(argumentSpecs);
-            return 
-                new List<IArgumentSpecification>(
-                    arguments.Select(
-                        (argument, i) => _argumentSpecificationFactory.Create(
-                            argument, parameterInfos[i], suppliedArgumentSpecifications)
-                    )
-                );
+
+            var result = arguments
+                .Select((arg, i) => _argumentSpecificationFactory.Create(arg, parameterInfos[i], suppliedArgumentSpecifications))
+                .ToArray();
+
+            var remainingArgumentSpecifications = suppliedArgumentSpecifications.DequeueRemaining();
+            if (remainingArgumentSpecifications.Any())
+            {
+                throw new RedundantArgumentMatcherException(remainingArgumentSpecifications, suppliedArgumentSpecifications.AllSpecifications);
+            }
+
+            return result;
         }
     }
 }

--- a/src/NSubstitute/Core/Arguments/NonParamsArgumentSpecificationFactory.cs
+++ b/src/NSubstitute/Core/Arguments/NonParamsArgumentSpecificationFactory.cs
@@ -1,4 +1,3 @@
-using System;
 using NSubstitute.Exceptions;
 
 namespace NSubstitute.Core.Arguments
@@ -18,7 +17,9 @@ namespace NSubstitute.Core.Arguments
             {
                 return suppliedArgumentSpecifications.Dequeue();
             }
-            if (!suppliedArgumentSpecifications.AnyFor(argument, parameterInfo.ParameterType) || parameterInfo.IsOptional || parameterInfo.IsOut)
+
+            bool isAmbiguousSpecificationPresent = suppliedArgumentSpecifications.AnyFor(argument, parameterInfo.ParameterType);
+            if (!isAmbiguousSpecificationPresent || parameterInfo.IsOptional || parameterInfo.IsOut)
             {
                 return _argumentEqualsSpecificationFactory.Create(argument, parameterInfo.ParameterType);
             }

--- a/src/NSubstitute/Core/Arguments/NonParamsArgumentSpecificationFactory.cs
+++ b/src/NSubstitute/Core/Arguments/NonParamsArgumentSpecificationFactory.cs
@@ -22,7 +22,8 @@ namespace NSubstitute.Core.Arguments
             {
                 return _argumentEqualsSpecificationFactory.Create(argument, parameterInfo.ParameterType);
             }
-            throw new AmbiguousArgumentsException();
+
+            throw new AmbiguousArgumentsException(suppliedArgumentSpecifications.AllSpecifications);
         }
     }
 }

--- a/src/NSubstitute/Core/Arguments/ParamsArgumentSpecificationFactory.cs
+++ b/src/NSubstitute/Core/Arguments/ParamsArgumentSpecificationFactory.cs
@@ -11,21 +11,18 @@ namespace NSubstitute.Core.Arguments
         private readonly IArgumentEqualsSpecificationFactory _argumentEqualsSpecificationFactory;
         private readonly IArrayArgumentSpecificationsFactory _arrayArgumentSpecificationsFactory;
         private readonly IParameterInfosFromParamsArrayFactory _parameterInfosFromParamsArrayFactory;
-        private readonly ISuppliedArgumentSpecificationsFactory _suppliedArgumentSpecificationsFactory;
         private readonly IArrayContentsArgumentSpecificationFactory _arrayContentsArgumentSpecificationFactory;
 
         public ParamsArgumentSpecificationFactory(IDefaultChecker defaultChecker,
                                                 IArgumentEqualsSpecificationFactory argumentEqualsSpecificationFactory,
                                                 IArrayArgumentSpecificationsFactory arrayArgumentSpecificationsFactory,
                                                 IParameterInfosFromParamsArrayFactory parameterInfosFromParamsArrayFactory,
-                                                ISuppliedArgumentSpecificationsFactory suppliedArgumentSpecificationsFactory,
                                                 IArrayContentsArgumentSpecificationFactory arrayContentsArgumentSpecificationFactory)
         {
             _defaultChecker = defaultChecker;
             _argumentEqualsSpecificationFactory = argumentEqualsSpecificationFactory;
             _arrayArgumentSpecificationsFactory = arrayArgumentSpecificationsFactory;
             _parameterInfosFromParamsArrayFactory = parameterInfosFromParamsArrayFactory;
-            _suppliedArgumentSpecificationsFactory = suppliedArgumentSpecificationsFactory;
             _arrayContentsArgumentSpecificationFactory = arrayContentsArgumentSpecificationFactory;
         }
 
@@ -52,8 +49,7 @@ namespace NSubstitute.Core.Arguments
             else
             {
                 var paramterInfosFromParamsArray = _parameterInfosFromParamsArrayFactory.Create(argument, parameterInfo.ParameterType);
-                var suppliedArgumentSpecificationsFromParamsArray = _suppliedArgumentSpecificationsFactory.Create(suppliedArgumentSpecifications.DequeueRemaining());
-                var arrayArgumentSpecifications = _arrayArgumentSpecificationsFactory.Create(argument, paramterInfosFromParamsArray, suppliedArgumentSpecificationsFromParamsArray);
+                var arrayArgumentSpecifications = _arrayArgumentSpecificationsFactory.Create(argument, paramterInfosFromParamsArray, suppliedArgumentSpecifications);
                 return _arrayContentsArgumentSpecificationFactory.Create(arrayArgumentSpecifications, parameterInfo.ParameterType);
             }
 

--- a/src/NSubstitute/Core/Arguments/ParamsArgumentSpecificationFactory.cs
+++ b/src/NSubstitute/Core/Arguments/ParamsArgumentSpecificationFactory.cs
@@ -56,7 +56,8 @@ namespace NSubstitute.Core.Arguments
                 var arrayArgumentSpecifications = _arrayArgumentSpecificationsFactory.Create(argument, paramterInfosFromParamsArray, suppliedArgumentSpecificationsFromParamsArray);
                 return _arrayContentsArgumentSpecificationFactory.Create(arrayArgumentSpecifications, parameterInfo.ParameterType);
             }
-            throw new AmbiguousArgumentsException();
+
+            throw new AmbiguousArgumentsException(suppliedArgumentSpecifications.AllSpecifications);
         }
 
     }

--- a/src/NSubstitute/Core/Arguments/SuppliedArgumentSpecifications.cs
+++ b/src/NSubstitute/Core/Arguments/SuppliedArgumentSpecifications.cs
@@ -9,18 +9,19 @@ namespace NSubstitute.Core.Arguments
     {
         private readonly IDefaultChecker _defaultChecker;
         private readonly Queue<IArgumentSpecification> _queue;
-        private readonly List<IArgumentSpecification> _list;
+        public IEnumerable<IArgumentSpecification> AllSpecifications { get; }
 
         public SuppliedArgumentSpecifications(IDefaultChecker defaultChecker, IEnumerable<IArgumentSpecification> argumentSpecifications)
         {
             _defaultChecker = defaultChecker;
-            _list = new List<IArgumentSpecification>(argumentSpecifications);
-            _queue = new Queue<IArgumentSpecification>(_list);
+            AllSpecifications = argumentSpecifications.ToArray();
+            _queue = new Queue<IArgumentSpecification>(AllSpecifications);
         }
+
 
         public bool AnyFor(object argument, Type argumentType)
         {
-            return _list.Any(x => DoesArgSpecLookLikeItCouldBeForThisArgumentAndType(x, argument, argumentType));
+            return AllSpecifications.Any(x => DoesArgSpecLookLikeItCouldBeForThisArgumentAndType(x, argument, argumentType));
         }
 
         public bool IsNextFor(object argument, Type argumentType)

--- a/src/NSubstitute/Core/Arguments/SuppliedArgumentSpecifications.cs
+++ b/src/NSubstitute/Core/Arguments/SuppliedArgumentSpecifications.cs
@@ -1,19 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 
 namespace NSubstitute.Core.Arguments
 {
     public class SuppliedArgumentSpecifications : ISuppliedArgumentSpecifications
     {
-        private readonly IDefaultChecker _defaultChecker;
+        private readonly IArgumentSpecificationCompatibilityTester _argSpecCompatibilityTester;
         private readonly Queue<IArgumentSpecification> _queue;
         public IEnumerable<IArgumentSpecification> AllSpecifications { get; }
 
-        public SuppliedArgumentSpecifications(IDefaultChecker defaultChecker, IEnumerable<IArgumentSpecification> argumentSpecifications)
+        public SuppliedArgumentSpecifications(IArgumentSpecificationCompatibilityTester argSpecCompatibilityTester, IEnumerable<IArgumentSpecification> argumentSpecifications)
         {
-            _defaultChecker = defaultChecker;
+            _argSpecCompatibilityTester = argSpecCompatibilityTester;
             AllSpecifications = argumentSpecifications.ToArray();
             _queue = new Queue<IArgumentSpecification>(AllSpecifications);
         }
@@ -21,14 +20,14 @@ namespace NSubstitute.Core.Arguments
 
         public bool AnyFor(object argument, Type argumentType)
         {
-            return AllSpecifications.Any(x => DoesArgSpecLookLikeItCouldBeForThisArgumentAndType(x, argument, argumentType));
+            return AllSpecifications.Any(x => _argSpecCompatibilityTester.IsSpecificationCompatible(x, argument, argumentType));
         }
 
         public bool IsNextFor(object argument, Type argumentType)
         {
             if (_queue.Count <= 0) { return false; }
             var nextArgSpec = _queue.Peek();
-            return DoesArgSpecLookLikeItCouldBeForThisArgumentAndType(nextArgSpec, argument, argumentType);
+            return _argSpecCompatibilityTester.IsSpecificationCompatible(nextArgSpec, argument, argumentType);
         }
 
         public IArgumentSpecification Dequeue()
@@ -41,23 +40,6 @@ namespace NSubstitute.Core.Arguments
             var result = _queue.ToArray();
             _queue.Clear();
             return result;
-        }
-
-        private bool DoesArgSpecLookLikeItCouldBeForThisArgumentAndType(IArgumentSpecification argSpec, object argument, Type argumentType)
-        {
-            var typeArgSpecIsFor = argSpec.ForType;
-            return AreTypesCompatible(argumentType, typeArgSpecIsFor) && IsProvidedArgumentTheOneWeWouldGetUsingAnArgSpecForThisType(argument, typeArgSpecIsFor);
-        }
-
-        private bool IsProvidedArgumentTheOneWeWouldGetUsingAnArgSpecForThisType(object argument, Type typeArgSpecIsFor)
-        {
-            return _defaultChecker.IsDefault(argument, typeArgSpecIsFor);
-        }
-
-        private bool AreTypesCompatible(Type argumentType, Type typeArgSpecIsFor)
-        {
-            return argumentType.IsAssignableFrom(typeArgSpecIsFor) ||
-                (argumentType.IsByRef && !typeArgSpecIsFor.IsByRef && argumentType.IsAssignableFrom(typeArgSpecIsFor.MakeByRefType()));
         }
     }
 }

--- a/src/NSubstitute/Core/Arguments/SuppliedArgumentSpecificationsFactory.cs
+++ b/src/NSubstitute/Core/Arguments/SuppliedArgumentSpecificationsFactory.cs
@@ -1,20 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace NSubstitute.Core.Arguments
 {
     public class SuppliedArgumentSpecificationsFactory : ISuppliedArgumentSpecificationsFactory
     {
-        private readonly IDefaultChecker _defaultChecker;
+        private readonly IArgumentSpecificationCompatibilityTester _argumentSpecificationCompatTester;
 
-        public SuppliedArgumentSpecificationsFactory(IDefaultChecker defaultChecker)
+        public SuppliedArgumentSpecificationsFactory(IArgumentSpecificationCompatibilityTester argumentSpecificationCompatTester)
         {
-            _defaultChecker = defaultChecker;
+            _argumentSpecificationCompatTester = argumentSpecificationCompatTester;
         }
 
         public ISuppliedArgumentSpecifications Create(IEnumerable<IArgumentSpecification> argumentSpecifications)
         {
-            return new SuppliedArgumentSpecifications(_defaultChecker, argumentSpecifications);
+            return new SuppliedArgumentSpecifications(_argumentSpecificationCompatTester, argumentSpecifications);
         }
     }
 }

--- a/src/NSubstitute/Core/CallSpecificationFactoryFactoryYesThatsRight.cs
+++ b/src/NSubstitute/Core/CallSpecificationFactoryFactoryYesThatsRight.cs
@@ -14,7 +14,7 @@ namespace NSubstitute.Core
                                 NewParamsArgumentSpecificationFactory(),
                                 NewNonParamsArgumentSpecificationFactory()
                                 ),
-                            new SuppliedArgumentSpecificationsFactory(NewDefaultChecker())
+                            new SuppliedArgumentSpecificationsFactory(new ArgumentSpecificationCompatibilityTester(NewDefaultChecker()))
                             )
                         )
                     );

--- a/src/NSubstitute/Core/CallSpecificationFactoryFactoryYesThatsRight.cs
+++ b/src/NSubstitute/Core/CallSpecificationFactoryFactoryYesThatsRight.cs
@@ -14,22 +14,20 @@ namespace NSubstitute.Core
                                 NewParamsArgumentSpecificationFactory(),
                                 NewNonParamsArgumentSpecificationFactory()
                                 ),
-                            new SuppliedArgumentSpecificationsFactory(new ArgumentSpecificationCompatibilityTester(NewDefaultChecker()))
+                            new SuppliedArgumentSpecificationsFactory(
+                                new ArgumentSpecificationCompatibilityTester(
+                                    new DefaultChecker(new DefaultForType())
+                                    )
+                                )
                             )
                         )
                     );
-        }
-
-        private static IDefaultChecker NewDefaultChecker()
-        {
-            return new DefaultChecker(new DefaultForType());
         }
 
         private static IParamsArgumentSpecificationFactory NewParamsArgumentSpecificationFactory()
         {
             return
                 new ParamsArgumentSpecificationFactory(
-                    NewDefaultChecker(),
                     new ArgumentEqualsSpecificationFactory(),
                     new ArrayArgumentSpecificationsFactory(
                         new NonParamsArgumentSpecificationFactory(new ArgumentEqualsSpecificationFactory())

--- a/src/NSubstitute/Core/CallSpecificationFactoryFactoryYesThatsRight.cs
+++ b/src/NSubstitute/Core/CallSpecificationFactoryFactoryYesThatsRight.cs
@@ -35,7 +35,6 @@ namespace NSubstitute.Core
                         new NonParamsArgumentSpecificationFactory(new ArgumentEqualsSpecificationFactory())
                     ),
                     new ParameterInfosFromParamsArrayFactory(),
-                    new SuppliedArgumentSpecificationsFactory(NewDefaultChecker()),
                     new ArrayContentsArgumentSpecificationFactory()
                 );
         }

--- a/src/NSubstitute/Core/PropertyHelper.cs
+++ b/src/NSubstitute/Core/PropertyHelper.cs
@@ -1,16 +1,20 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using NSubstitute.Core.Arguments;
 
 namespace NSubstitute.Core
 {
     public class PropertyHelper : IPropertyHelper
     {
         private readonly ICallFactory _callFactory;
+        private readonly IArgumentSpecificationCompatibilityTester _argSpecCompatTester;
 
-        public PropertyHelper(ICallFactory callFactory)
+        public PropertyHelper(ICallFactory callFactory, IArgumentSpecificationCompatibilityTester argSpecCompatTester)
         {
             _callFactory = callFactory;
+            _argSpecCompatTester = argSpecCompatTester;
         }
         
         public bool IsCallToSetAReadWriteProperty(ICall call)
@@ -36,10 +40,38 @@ namespace NSubstitute.Core
             {
                 throw new InvalidOperationException("Could not find a GetMethod for \"" + callToSetter.GetMethodInfo() + "\"");
             }
-            var setterArgs = callToSetter.GetArguments();
+
             var getter = propertyInfo.GetGetMethod();
-            var getterArgs = setterArgs.Take(setterArgs.Length - 1).ToArray();
-            return _callFactory.Create(getter, getterArgs, callToSetter.Target(), callToSetter.GetArgumentSpecifications());
+            var getterArgs = SkipLast(callToSetter.GetArguments());
+            var getterArgumentSpecifications = GetGetterCallSpecificationsFromSetterCall(callToSetter);
+
+            return _callFactory.Create(getter, getterArgs, callToSetter.Target(), getterArgumentSpecifications);
+        }
+
+        private IList<IArgumentSpecification> GetGetterCallSpecificationsFromSetterCall(ICall callToSetter)
+        {
+            var lastSetterArg = callToSetter.GetOriginalArguments().Last();
+            var lastSetterArgType = callToSetter.GetParameterInfos().Last().ParameterType;
+
+            var argumentSpecifications = callToSetter.GetArgumentSpecifications();
+            if (argumentSpecifications.Count == 0)
+                return argumentSpecifications;
+
+            // Getter call has one less argument than the setter call (the last arg is trimmed).
+            // Therefore, we need to remove the last argument specification if it's for the trimmed arg.
+            // Otherwise, NSubstitute might find that the redundant argument specification is present and the
+            // validation logic might trigger an exception.
+            if (_argSpecCompatTester.IsSpecificationCompatible(argumentSpecifications.Last(), lastSetterArg, lastSetterArgType))
+            {
+                argumentSpecifications = SkipLast(argumentSpecifications);
+            }
+
+            return argumentSpecifications;
+        }
+
+        private static T[] SkipLast<T>(ICollection<T> collection)
+        {
+            return collection.Take(collection.Count - 1).ToArray();
         }
     }
 }

--- a/src/NSubstitute/Exceptions/AmbiguousArgumentsException.cs
+++ b/src/NSubstitute/Exceptions/AmbiguousArgumentsException.cs
@@ -1,12 +1,25 @@
 using System;
+using System.Collections.Generic;
+using NSubstitute.Core.Arguments;
 
 namespace NSubstitute.Exceptions
 {
     public class AmbiguousArgumentsException : SubstituteException
     {
-        public static string SpecifyAllArguments = "Cannot determine argument specifications to use." + Environment.NewLine +
-                                                    "Please use specifications for all arguments of the same type.";
-        public AmbiguousArgumentsException() : this(SpecifyAllArguments) { }
-        public AmbiguousArgumentsException(string message) : base(message) { }
+        public AmbiguousArgumentsException(IEnumerable<IArgumentSpecification> queuedSpecifications)
+            : this(BuildExceptionMessage(queuedSpecifications))
+        {
+        }
+
+        public AmbiguousArgumentsException(string message) : base(message)
+        {
+        }
+
+        private static string BuildExceptionMessage(IEnumerable<IArgumentSpecification> queuedSpecifications)
+        {
+            return $"Cannot determine argument specifications to use. Please use specifications for all arguments of the same type.{Environment.NewLine}" +
+                   $"All queued specifications:{Environment.NewLine}" +
+                   $"{string.Join(Environment.NewLine, queuedSpecifications)}";
+        }
     }
 }

--- a/src/NSubstitute/Exceptions/AmbiguousArgumentsException.cs
+++ b/src/NSubstitute/Exceptions/AmbiguousArgumentsException.cs
@@ -6,6 +6,12 @@ namespace NSubstitute.Exceptions
 {
     public class AmbiguousArgumentsException : SubstituteException
     {
+        private static readonly string BaseMessage =
+            "Cannot determine argument specifications to use. Please use specifications for all arguments of the same type." +
+            Environment.NewLine +
+            "All queued specifications:" +
+            Environment.NewLine;
+
         public AmbiguousArgumentsException(IEnumerable<IArgumentSpecification> queuedSpecifications)
             : this(BuildExceptionMessage(queuedSpecifications))
         {
@@ -17,9 +23,7 @@ namespace NSubstitute.Exceptions
 
         private static string BuildExceptionMessage(IEnumerable<IArgumentSpecification> queuedSpecifications)
         {
-            return $"Cannot determine argument specifications to use. Please use specifications for all arguments of the same type.{Environment.NewLine}" +
-                   $"All queued specifications:{Environment.NewLine}" +
-                   $"{string.Join(Environment.NewLine, queuedSpecifications)}";
+            return BaseMessage + "    " + string.Join(Environment.NewLine + "    ", queuedSpecifications);
         }
     }
 }

--- a/src/NSubstitute/Exceptions/RedundantArgumentMatcherException.cs
+++ b/src/NSubstitute/Exceptions/RedundantArgumentMatcherException.cs
@@ -21,9 +21,11 @@ namespace NSubstitute.Exceptions
         {
             return
                 $"Not all the argument specifications (e.g. Arg.Is, Arg.Any) were bound during the last call.{Environment.NewLine}" +
-                $"Usually, it means that previously you passed specifications to methods, which are not handled" +
-                $" by the NSubstitute (e.g. methods are not virtual, or don't belong to a substitute)." +
-                $" That is an indication of the invalid NSubstitute usage and most likely your test code behaves not as you expect.{Environment.NewLine}" +
+                $"It could mean that previously you passed specification to a method, which is not handled" +
+                $" by the NSubstitute (e.g. method is not virtual, or doesn't belong to a substitute). Another reason" +
+                $" might be that argument specification type doesn't match the actual argument type, but code compiles due" +
+                $" to an implicit cast (e.g. between 'int' and 'double'). In any case this exception is an indication" +
+                $" of the unexpected NSubstitute usage and most likely your test code behaves not as intended.{Environment.NewLine}" +
                 $"Please use the diagnostics information below to detect and fix the defective places.{Environment.NewLine}" +
                 $"{Environment.NewLine}" +
                 $"Remaining (non-bound) argument specifications:{Environment.NewLine}" +

--- a/src/NSubstitute/Exceptions/RedundantArgumentMatcherException.cs
+++ b/src/NSubstitute/Exceptions/RedundantArgumentMatcherException.cs
@@ -1,11 +1,50 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using NSubstitute.Core.Arguments;
+using static System.Environment;
 
 namespace NSubstitute.Exceptions
 {
     public class RedundantArgumentMatcherException : SubstituteException
     {
+        private static readonly string ItemSeparator = NewLine + "    ";
+
+        private static readonly string BaseMessage =
+            "Some argument specifications (e.g. Arg.Is, Arg.Any) were left over after the last call." +
+            NewLine +
+            NewLine +
+            "This is often caused by using an argument spec with a call to a member NSubstitute does not handle" +
+            " (such as a non-virtual member or a call to an instance which is not a substitute), or for a purpose" +
+            " other than specifying a call (such as using an arg spec as a return value). For example:" +
+            NewLine +
+            NewLine +
+            "    var sub = Substitute.For<SomeClass>();" + NewLine +
+            "    var realType = new MyRealType(sub);" + NewLine +
+            "    // INCORRECT, arg spec used on realType, not a substitute:" + NewLine +
+            "    realType.SomeMethod(Arg.Any<int>());" + NewLine +
+            "    // INCORRECT, arg spec used as a return value, not to specify a call:" + NewLine +
+            "    sub.VirtualMethod(2).Returns(Arg.Any<int>());" + NewLine +
+            "    // INCORRECT, arg spec used with a non-virtual method:" + NewLine +
+            "    sub.NonVirtualMethod(Arg.Any<int>()).Returns(2);" + NewLine +
+            "    // CORRECT, arg spec used to specify virtual call on a substitute:" + NewLine +
+            "    sub.VirtualMethod(Arg.Any<int>()).Returns(2);" + NewLine +
+            NewLine +
+            "To fix this make sure you only use argument specifications with calls to substitutes. If your substitute" +
+            " is a class, make sure the member is virtual." +
+            NewLine +
+            NewLine +
+            "Another possible cause is that the argument spec type does not match the actual argument type," +
+            " but code compiles due to an implicit cast. For example, Arg.Any<int>() was used, but Arg.Any<double>()" +
+            " was required." +
+            NewLine +
+            NewLine +
+            "NOTE: the cause of this exception can be in a previously executed test. Use the diagnostics below to see the" +
+            " types of any redundant arg specs, then work out where they are being created." +
+            NewLine +
+            NewLine +
+            "Diagnostic information:" +
+            NewLine +
+            NewLine;
+
         public RedundantArgumentMatcherException(IEnumerable<IArgumentSpecification> remainingSpecifications,
             IEnumerable<IArgumentSpecification> allSpecifications)
             : this(FormatErrorMessage(remainingSpecifications, allSpecifications))
@@ -20,19 +59,13 @@ namespace NSubstitute.Exceptions
             IEnumerable<IArgumentSpecification> allSpecifications)
         {
             return
-                $"Not all the argument specifications (e.g. Arg.Is, Arg.Any) were bound during the last call.{Environment.NewLine}" +
-                $"It could mean that previously you passed specification to a method, which is not handled" +
-                $" by the NSubstitute (e.g. method is not virtual, or doesn't belong to a substitute). Another reason" +
-                $" might be that argument specification type doesn't match the actual argument type, but code compiles due" +
-                $" to an implicit cast (e.g. between 'int' and 'double'). In any case this exception is an indication" +
-                $" of the unexpected NSubstitute usage and most likely your test code behaves not as intended.{Environment.NewLine}" +
-                $"Please use the diagnostics information below to detect and fix the defective places.{Environment.NewLine}" +
-                $"{Environment.NewLine}" +
-                $"Remaining (non-bound) argument specifications:{Environment.NewLine}" +
-                $"{string.Join(Environment.NewLine, remainingSpecifications)}{Environment.NewLine}" +
-                $"{Environment.NewLine}" +
-                $"All argument specifications:{Environment.NewLine}" +
-                $"{string.Join(Environment.NewLine, allSpecifications)}";
+                BaseMessage +
+                $"Remaining (non-bound) argument specifications:{ItemSeparator}" +
+                $"{string.Join(ItemSeparator, remainingSpecifications)}{NewLine}" +
+                NewLine +
+                $"All argument specifications:{ItemSeparator}" +
+                $"{string.Join(ItemSeparator, allSpecifications)}" +
+                NewLine;
         }
     }
 }

--- a/src/NSubstitute/Exceptions/RedundantArgumentMatcherException.cs
+++ b/src/NSubstitute/Exceptions/RedundantArgumentMatcherException.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using NSubstitute.Core.Arguments;
+
+namespace NSubstitute.Exceptions
+{
+    public class RedundantArgumentMatcherException : SubstituteException
+    {
+        public RedundantArgumentMatcherException(IEnumerable<IArgumentSpecification> remainingSpecifications,
+            IEnumerable<IArgumentSpecification> allSpecifications)
+            : this(FormatErrorMessage(remainingSpecifications, allSpecifications))
+        {
+        }
+
+        public RedundantArgumentMatcherException(string message) : base(message)
+        {
+        }
+
+        private static string FormatErrorMessage(IEnumerable<IArgumentSpecification> remainingSpecifications,
+            IEnumerable<IArgumentSpecification> allSpecifications)
+        {
+            return
+                $"Not all the argument specifications (e.g. Arg.Is, Arg.Any) were bound during the last call.{Environment.NewLine}" +
+                $"Usually, it means that previously you passed specifications to methods, which are not handled" +
+                $" by the NSubstitute (e.g. methods are not virtual, or don't belong to a substitute)." +
+                $" That is an indication of the invalid NSubstitute usage and most likely your test code behaves not as you expect.{Environment.NewLine}" +
+                $"Please use the diagnostics information below to detect and fix the defective places.{Environment.NewLine}" +
+                $"{Environment.NewLine}" +
+                $"Remaining (non-bound) argument specifications:{Environment.NewLine}" +
+                $"{string.Join(Environment.NewLine, remainingSpecifications)}{Environment.NewLine}" +
+                $"{Environment.NewLine}" +
+                $"All argument specifications:{Environment.NewLine}" +
+                $"{string.Join(Environment.NewLine, allSpecifications)}";
+        }
+    }
+}

--- a/src/NSubstitute/Routing/RouteFactory.cs
+++ b/src/NSubstitute/Routing/RouteFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NSubstitute.Core;
+using NSubstitute.Core.Arguments;
 using NSubstitute.ReceivedExtensions;
 using NSubstitute.Routing.Handlers;
 
@@ -58,7 +59,7 @@ namespace NSubstitute.Routing
         {
             return new Route(new ICallHandler[] {
                 new RecordCallSpecificationHandler(state.PendingSpecification, state.CallSpecificationFactory, state.CallActions)
-                , new PropertySetterHandler(new PropertyHelper(new CallFactory()), state.ConfigureCall)
+                , new PropertySetterHandler(new PropertyHelper(new CallFactory(), new ArgumentSpecificationCompatibilityTester(new DefaultChecker(new DefaultForType()))), state.ConfigureCall)
                 , new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.AutoValuesCallResults, state.CallSpecificationFactory)
                 , new ReturnFromAndConfigureDynamicCall(state.ConfigureCall)
                 , ReturnDefaultForReturnTypeHandler()
@@ -71,7 +72,7 @@ namespace NSubstitute.Routing
                 , new TrackLastCallHandler(state.PendingSpecification)
                 , new RecordCallHandler(state.CallCollection, state.SequenceNumberGenerator)
                 , new EventSubscriptionHandler(state.EventHandlerRegistry)
-                , new PropertySetterHandler(new PropertyHelper(new CallFactory()), state.ConfigureCall)
+                , new PropertySetterHandler(new PropertyHelper(new CallFactory(), new ArgumentSpecificationCompatibilityTester(new DefaultChecker(new DefaultForType()))), state.ConfigureCall)
                 , new DoActionsCallHandler(state.CallActions)
                 , new ReturnConfiguredResultHandler(state.CallResults)
                 , new ReturnResultForTypeHandler(state.ResultsForType)

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
@@ -147,9 +147,8 @@ namespace NSubstitute.Acceptance.Specs
             Assert.Throws<AmbiguousArgumentsException>(() =>
                {
                    _something.Add(0, Arg.Any<int>()).Returns(1);
-                   //Should not make it here, as it can't work out which arg the matcher refers to.
-                   //If it does this will throw an AssertionException rather than AmbiguousArgumentsException.
-                   Assert.That(_something.Add(0, 5), Is.EqualTo(1));
+                   Assert.Fail("Should not make it here, as it can't work out which arg the matcher refers to." +
+                               "If it does this will throw an AssertionException rather than AmbiguousArgumentsException.");
                }
                 );
         }

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
@@ -155,6 +155,17 @@ namespace NSubstitute.Acceptance.Specs
         }
 
         [Test]
+        public void Should_add_list_of_all_pending_specifications_to_ambiguous_exception_message()
+        {
+            var exception = Assert.Throws<AmbiguousArgumentsException>(() =>
+            {
+                _something.Add(0, Arg.Is(42)).Returns(1);
+            });
+
+            Assert.That(exception.Message, Contains.Substring("42"));
+        }
+
+        [Test]
         public void Returns_should_work_with_params()
         {
             _something.WithParams(Arg.Any<int>(), Arg.Is<string>(x => x == "one")).Returns("fred");

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
@@ -264,6 +264,40 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(result, Is.EqualTo(42));
         }
 
+        [Test]
+        public void Should_fail_with_redundant_exception_if_more_specifications_than_arguments_scenario_1()
+        {
+            // This spec will be ignored, however it's good to let user know that test might not work how he expects.
+            Arg.Is(42);
+
+            Assert.Throws<RedundantArgumentMatcherException>(() =>
+            {
+                _something.Echo(10);
+            });
+        }
+
+        [Test]
+        public void Should_fail_with_redundant_exception_if_more_specifications_than_arguments_scenario_2()
+        {
+            // This one will be used instead of Arg.Any<>(), causing the confusion.
+            Arg.Is(42);
+
+            Assert.Throws<RedundantArgumentMatcherException>(() =>
+            {
+                _something.Echo(Arg.Any<int>());
+            });
+        }
+
+        [Test]
+        public void Redundant_argument_matcher_exception_should_contain_list_of_all_matchers()
+        {
+            Arg.Is(42);
+
+            var ex = Assert.Throws<RedundantArgumentMatcherException>(() => { _something.Echo(Arg.Is(24)); });
+            Assert.That(ex.Message, Contains.Substring("42"));
+            Assert.That(ex.Message, Contains.Substring("24"));
+        }
+
         [SetUp]
         public void SetUp()
         {

--- a/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
+++ b/tests/NSubstitute.Acceptance.Specs/ArgumentMatching.cs
@@ -226,6 +226,44 @@ namespace NSubstitute.Acceptance.Specs
             Assert.That(_something.WithNullableArg(234), Is.EqualTo(123));
         }
 
+        public interface IMethodsWithParamsArgs
+        {
+            int GetValue(int primary, params int[] others);
+        }
+
+        [Test]
+        public void Should_fail_with_ambiguous_exception_if_params_boundary_is_crossed_scenario_1()
+        {
+            var target = Substitute.For<IMethodsWithParamsArgs>();
+
+            Assert.Throws<AmbiguousArgumentsException>(() =>
+            {
+                target.GetValue(0, Arg.Any<int>()).Returns(42);
+            });
+        }
+
+        [Test]
+        public void Should_fail_with_ambiguous_exception_if_params_boundary_is_crossed_scenario_2()
+        {
+            var target = Substitute.For<IMethodsWithParamsArgs>();
+
+            Assert.Throws<AmbiguousArgumentsException>(() =>
+            {
+                target.GetValue(Arg.Any<int>(), 0).Returns(42);
+            });
+        }
+
+        [Test]
+        public void Should_correctly_use_matchers_crossing_the_params_boundary()
+        {
+            var target = Substitute.For<IMethodsWithParamsArgs>();
+            target.GetValue(Arg.Is(0), Arg.Any<int>()).Returns(42);
+
+            var result = target.GetValue(0, 100);
+
+            Assert.That(result, Is.EqualTo(42));
+        }
+
         [SetUp]
         public void SetUp()
         {

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue279_ShouldFailOnRedundantArguments.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue279_ShouldFailOnRedundantArguments.cs
@@ -1,0 +1,37 @@
+﻿using NSubstitute.Exceptions;
+using NUnit.Framework;
+
+namespace NSubstitute.Acceptance.Specs.FieldReports
+{
+    public class Issue279_ShouldFailOnRedundantArguments
+    {
+        public interface IFoo
+        {
+            int Blah(double s);
+        }
+
+        [Test]
+        public void Should_fail_with_redundant_exception_if_matcher_is_not_used_due_to_implicit_cast_scenario_1()
+        {
+            var foo = Substitute.For<IFoo>();
+
+            Assert.Throws<RedundantArgumentMatcherException>(() =>
+            {
+                foo.Blah(Arg.Any<int>()).Returns(42);
+            });
+        }
+
+        [Test]
+        public void Should_fail_with_redundant_exception_if_matcher_is_not_used_due_to_implicit_cast_scenario_2()
+        {
+            var foo = Substitute.For<IFoo>();
+
+            Assert.Throws<RedundantArgumentMatcherException>(() =>
+            {
+                // Fails because Is<T>() type is deduced to int, so specifier is not matched later.
+                foo.Blah(Arg.Is(10)).Returns(42);
+            });
+        }
+
+    }
+}

--- a/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue279_ShouldFailOnRedundantArguments.cs
+++ b/tests/NSubstitute.Acceptance.Specs/FieldReports/Issue279_ShouldFailOnRedundantArguments.cs
@@ -33,5 +33,15 @@ namespace NSubstitute.Acceptance.Specs.FieldReports
             });
         }
 
+        [Test]
+        public void Should_fail_with_redundant_exceptions_if_arg_matchers_misused()
+        {
+            var foo = Substitute.For<IFoo>();
+            var misued = Arg.Is("test");
+            Assert.Throws<RedundantArgumentMatcherException>(() =>
+            {
+                foo.Blah(2.0).Returns(42);
+            });
+        }
     }
 }


### PR DESCRIPTION
Not sure if the message is too wordy now, but I wanted to try to add some more information on how to fix the problem and some examples of misusing the arg matchers. Feel free to reject/reword.